### PR TITLE
Support classpath's as versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,16 @@ After cloning this project. and use `sbt clean core/assembly`.
 % function jardiff() {   java $JAVA_OPTS -jar /code/jardiff/core/target/scala-2.12/jardiff-core-assembly-*.jar "$@"; }
 
 % jardiff -h
-  usage: jardiff [-c] [-g <dir>] [-h] [-q] [-U <n>] <jar/directory/url> [<jar/directory/url> ...]
-   -c,--suppress-code   Suppress method bodies
-   -g,--git <dir>       Directory to output a git repository containing the diff
-   -h,--help            Display this message
-   -q,--quiet           Don't output diffs to standard out
-   -U,--unified <n>     Number of context lines in diff
+usage: jardiff [-c] [-g <dir>] [-h] [-q] [-U <n>] VERSION1 [VERSION2 ...]
 
+Each VERSION may designate a single file, a directory, JAR file or a
+`:`-delimited classpath
+
+ -c,--suppress-code   Suppress method bodies
+ -g,--git <dir>       Directory to output a git repository containing the diff
+ -h,--help            Display this message
+ -q,--quiet           Don't output diffs to standard out
+ -U,--unified <n>     Number of context lines in diff
 
 % jardiff dir1 dir2
 

--- a/core/src/main/scala/scala/tools/jardiff/FileRenderer.scala
+++ b/core/src/main/scala/scala/tools/jardiff/FileRenderer.scala
@@ -4,7 +4,7 @@
 
 package scala.tools.jardiff
 
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, StandardCopyOption}
 
 trait FileRenderer {
   def outFileExtension: String
@@ -16,6 +16,6 @@ object IdentityRenderer extends FileRenderer {
   def outFileExtension: String = ""
 
   override def render(in: Path, out: Path): Unit = {
-    Files.copy(in, out)
+    Files.copy(in, out, StandardCopyOption.REPLACE_EXISTING)
   }
 }


### PR DESCRIPTION
Example:

```
jardiff v1/a.jar:v1/b.jar v2/a.jar:v2/b.jar
```

Or even:

```
% jardiff --quiet --git /tmp/scala-all-diff $(ls ~/scala/2.11.2/lib/* | paste -s -d':' -) $(ls ~/scala/2.11.3/lib/* | paste -s -d':' -)
```