### PR TITLE
Support reading jar file with space in the name.

### DIFF
--- a/core/src/main/scala/scala/tools/jardiff/IOUtil.scala
+++ b/core/src/main/scala/scala/tools/jardiff/IOUtil.scala
@@ -21,7 +21,7 @@ object IOUtil {
       if (index == -1) {
         fileOrZip
       } else {
-        val uri = URI.create("jar:file:" + Paths.get(fileOrZip.toString.substring(0, index + extSlash.length - 1)).toUri.getPath)
+        val uri = URI.create("jar:" + Paths.get(fileOrZip.toString.substring(0, index + extSlash.length - 1)).toUri.toString)
         val jarEntry = fileOrZip.toString.substring(index + extSlash.length - 1)
         val system = newFileSystem(uri, new util.HashMap[String, Any]())
         system.getPath(jarEntry)


### PR DESCRIPTION
```scala
@ java.net.URI.create("jar:file:/C:/Program Files/Java/jdk1.8.0/jre/lib/resources.jar")
java.lang.IllegalArgumentException: Illegal character in opaque part at index 20: jar:file:/C:/Program Files/Java/jdk1.8.0/jre/lib/resources.jar
@ java.net.URI.create("jar:file:/C:/Program%20Files/Java/jdk1.8.0/jre/lib/resources.jar")
res2: java.net.URI = jar:file:/C:/Program%20Files/Java/jdk1.8.0/jre/lib/resources.jar
@ Paths.get("U A").toUri.getPath
res3: String = "/Users/ollie/dev/scalameta/U A"
@ Paths.get("U A").toUri.toString
res4: String = "file:///Users/ollie/dev/scalameta/U%20A"
```

I couldn't find where to test this change. I am surprised nio requires this fragile conversion from Path to URI to read a zip/jar file.