### PR TITLE
Support ignoring file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,21 @@ Installing
 }
 
 % jardiff -h
-usage: jardiff [-c] [-g <dir>] [-h] [-q] [-U <n>] VERSION1 [VERSION2 ...]
+usage: jardiff [-c] [-g <dir>] [-h] [-i <arg>] [-p] [-q] [-r] [-U <n>] VERSION1 [VERSION2 ...]
 
 Each VERSION may designate a single file, a directory, JAR file or a
 `:`-delimited classpath
 
- -c,--suppress-code   Suppress method bodies
- -g,--git <dir>       Directory to output a git repository containing the diff
- -h,--help            Display this message
- -q,--quiet           Don't output diffs to standard out
- -r,--raw             Disable sorting and filtering of classfile contents
- -U,--unified <n>     Number of context lines in diff
+ -c,--suppress-code       Suppress method bodies
+ -g,--git <dir>           Directory to output a git repository containing the
+                          diff
+ -h,--help                Display this message
+ -i,--ignore <arg>        File pattern to ignore rendered files in gitignore
+                          format
+ -p,--suppress-privates   Display only non-private members
+ -q,--quiet               Don't output diffs to standard out
+ -r,--raw                 Disable sorting and filtering of classfile contents
+ -U,--unified <n>         Number of context lines in diff
 
 % jardiff dir1 dir2
 

--- a/core/src/main/scala/scala/tools/jardiff/IOUtil.scala
+++ b/core/src/main/scala/scala/tools/jardiff/IOUtil.scala
@@ -84,7 +84,4 @@ object IOUtil {
       }
     })
   }
-
-
-
 }


### PR DESCRIPTION
One or more `-i` options can be provided, which are taken as entries
for a `gitignore` file that is used to filter rendered entries
from the diff.

For example `-i com/foo/F.class.* -i com/foo/impl/`  would filter
all renderings of the class `com.foo.F` and of the contents of
the `impl` package. `-i *.class.scalap` would filter the diff
of the Scala Signature.

Fixes #36 