### PR TITLE
Disable GPG signing on git commits

### DIFF
--- a/core/src/main/scala/scala/tools/jardiff/JarDiff.scala
+++ b/core/src/main/scala/scala/tools/jardiff/JarDiff.scala
@@ -41,8 +41,9 @@ final class JarDiff(files: List[List[Path]], config: JarDiff.Config, renderers: 
         val status = git.status().call()
         val ignored = status.getIgnoredNotInIndex
         ignored.forEach(p => IOUtil.deleteRecursive(targetBase.resolve(p)))
+        val msg = s"jardiff textified output of: ${fs.mkString(File.pathSeparator)}"
         git.add().addFilepattern(".").call()
-        git.commit().setAllowEmpty(true).setAll(true).setMessage("jardiff textified output of: " + fs.mkString(File.pathSeparator)).call()
+        git.commit().setAllowEmpty(true).setAll(true).setMessage(msg).setSign(false).call()
       }
 
       files match {


### PR DESCRIPTION
Without this I'm getting, for unclear reasons:

    org.eclipse.jgit.api.errors.JGitInternalException: missing credentials provider
    	at org.eclipse.jgit.lib.internal.BouncyCastleGpgSigner.sign(BouncyCastleGpgSigner.java:157)
    	at org.eclipse.jgit.api.CommitCommand.call(CommitCommand.java:271)
    	at scala.tools.jardiff.JarDiff.renderAndCommit$1(JarDiff.scala:46)
    	at scala.tools.jardiff.JarDiff.$anonfun$diff$3(JarDiff.scala:53)
    	at scala.collection.Iterator$$anon$9.next(Iterator.scala:554)
    	at scala.collection.Iterator$GroupedIterator.takeDestructively(Iterator.scala:205)
    	at scala.collection.Iterator$GroupedIterator.go(Iterator.scala:220)
    	at scala.collection.Iterator$GroupedIterator.fill(Iterator.scala:257)
    	at scala.collection.Iterator$GroupedIterator.hasNext(Iterator.scala:261)
    	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:578)
    	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:576)
    	at scala.collection.AbstractIterator.foreach(Iterator.scala:1196)
    	at scala.tools.jardiff.JarDiff.diff(JarDiff.scala:54)
    	at scala.tools.jardiff.Main$.run(Main.scala:84)
    	at scala.tools.jardiff.Main$.main(Main.scala:20)
    	at scala.tools.jardiff.Main.main(Main.scala)
    Caused by: org.bouncycastle.openpgp.PGPException: missing credentials provider
    	at org.eclipse.jgit.lib.internal.BouncyCastleGpgKeyPassphrasePrompt.getPassphrase(BouncyCastleGpgKeyPassphrasePrompt.java:120)
    	at org.eclipse.jgit.lib.internal.BouncyCastleGpgKeyLocator.findSecretKeyForKeyBoxPublicKey(BouncyCastleGpgKeyLocator.java:279)
    	at org.eclipse.jgit.lib.internal.BouncyCastleGpgKeyLocator.findSecretKey(BouncyCastleGpgKeyLocator.java:244)
    	at org.eclipse.jgit.lib.internal.BouncyCastleGpgSigner.locateSigningKey(BouncyCastleGpgSigner.java:120)
    	at org.eclipse.jgit.lib.internal.BouncyCastleGpgSigner.sign(BouncyCastleGpgSigner.java:129)
    	... 15 more