### PR TITLE
Add error handling for MatchError in ScalapRenderer

### DIFF
--- a/core/src/main/scala/scala/tools/jardiff/ScalapRenderer.scala
+++ b/core/src/main/scala/scala/tools/jardiff/ScalapRenderer.scala
@@ -23,6 +23,8 @@ class ScalapRenderer(privates: Boolean) extends FileRenderer {
     } catch {
       case err: ScalaSigParserError =>
         System.err.println("WARN: unable to invoke scalap on: " + in + ": " + err.getMessage)
+      case matchErr: MatchError =>
+        System.err.println("WARN: unable to invoke scalap on: " + in + ": " + matchErr.getMessage)
     }
   }
 }


### PR DESCRIPTION
Prevents MatchError from making jardiff not work, copied same code from ScalaSigParserError to a new case block. Seems to compile and work fine locally for me, but I don't actually know Scala, only Java/Kotlin, so please let me know if there's any better way to catch multiple exceptions while running the same code (there probably is but this was the first solution that compiled for me so I kept it).

This does not fix the root cause of any MatchError, just turns it into non-fatal failure which makes all other non-erroring classes get jardiffed correctly.